### PR TITLE
Fix a typo

### DIFF
--- a/subprojects/guide/src/docs/asciidoc/plugins/licensing-gradle-plugin.adoc
+++ b/subprojects/guide/src/docs/asciidoc/plugins/licensing-gradle-plugin.adoc
@@ -39,7 +39,7 @@ config {
 [options="header", cols="5*"]
 |===
 | Name     | Type       | Required | Default Value | Description
-| enabled  | boolean    | no       | true          | Disables `org.kordamp.gradle.javadoc` plugin if `false`
+| enabled  | boolean    | no       | true          | Disables `org.kordamp.gradle.licensing` plugin if `false`
 | licenses | LicenseSet | yes      |               | This block maps to the `<licenses>` block in POM. +
                                                      At least one nested `license` block must be defined.
 |===


### PR DESCRIPTION
org.kordamp.gradle.javadoc => org.kordamp.gradle.licensing