### PR TITLE
Add lines setting root project name in sample settings.gradle(.kts)

### DIFF
--- a/subprojects/guide/src/docs/asciidoc/project-structure.adoc
+++ b/subprojects/guide/src/docs/asciidoc/project-structure.adoc
@@ -140,6 +140,8 @@ buildscript {
 }
 apply plugin: 'org.kordamp.gradle.settings'
 
+rootProject.name = 'root'
+
 projects {
     directories = ['docs', 'subprojects']
 }
@@ -157,6 +159,8 @@ buildscript {
     }
 }
 apply(plugin = "org.kordamp.gradle.settings")
+
+rootProject.name = "root"
 
 projects {
     directories = listOf("docs", "subprojects")


### PR DESCRIPTION
Lines setting `rootProject.name` are already present in the "lower-level" code snippets that are above the snippets edited here.

Besides, tab names `settings.gradle(.kts)` suggest these are complete settings files, and without `rootProject.name = ...` they seem incomplete.