### PR TITLE
[base] Fixed org.kordamp.gradle.plugin.base.plugins.Plugin.merge

### DIFF
--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Plugin.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Plugin.groovy
@@ -102,8 +102,12 @@ class Plugin extends AbstractFeature {
 
     static void merge(Plugin o1, Plugin o2) {
         AbstractFeature.merge(o1, o2)
-        o1.id = o1.id ?: o2?.id
-        o1.implementationClass = o1.implementationClass ?: o2?.implementationClass
+        if (!o1.id && o2?.id) {
+            o1.id = o2.id
+        }
+        if (!o1.implementationClass && o2?.implementationClass) {
+            o1.implementationClass = o2.implementationClass
+        }
         CollectionUtils.merge(o1.tags, o2?.tags)
     }
 


### PR DESCRIPTION
Fixes #132.

Changed `Plugin.merge` so that `setId` / `setImplementationClass` are called only when `id` / `implementationClass` can change.