### PR TITLE
Add `maxDepth(1)` to `walkTopDown()`

### DIFF
--- a/subprojects/guide/src/docs/asciidoc/project-structure.adoc
+++ b/subprojects/guide/src/docs/asciidoc/project-structure.adoc
@@ -115,7 +115,7 @@ fun includeProject(projectDirName: String, projectName: String) {
 
 listOf("docs", "subprojects").forEach { dirName ->
     val subdir = File(rootDir, dirName)
-    subdir.walkTopDown().forEach { dir ->
+    subdir.walkTopDown().maxDepth(1).forEach { dir ->
         val buildFile = File(dir, "${dir.name}.gradle.kts")
         if (buildFile.exists()) {
             includeProject(dirName, dir.name)


### PR DESCRIPTION
Groovy version uses [`eachDir`](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/io/File.html#eachDir(groovy.lang.Closure)) which visits only child directories. Kotlin's [`walkTopDown()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/java.io.-file/walk-top-down.html) visits an entire tree unless [max depth](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/-file-tree-walk/max-depth.html) is specified.