### PR TITLE
Fix setting `-Xdoclint:none` and `-quiet` options for Javadoc

### DIFF
--- a/plugins/apidoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/apidoc/ApidocPlugin.groovy
+++ b/plugins/apidoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/apidoc/ApidocPlugin.groovy
@@ -193,7 +193,8 @@ class ApidocPlugin extends AbstractKordampPlugin {
             description 'Aggregates Javadoc API docs for all projects.'
             destinationDir project.file("${project.buildDir}/docs/javadoc")
             if (JavaVersion.current().isJava8Compatible()) {
-                options.addStringOption('Xdoclint:none', '-quiet')
+                options.addBooleanOption('Xdoclint:none', true)
+                options.quiet()
             }
         }
 

--- a/plugins/javadoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/javadoc/JavadocPlugin.groovy
+++ b/plugins/javadoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/javadoc/JavadocPlugin.groovy
@@ -114,7 +114,8 @@ class JavadocPlugin extends AbstractKordampPlugin {
                         task.options.footer = "Copyright &copy; ${effectiveConfig.info.copyrightYear} ${effectiveConfig.info.getAuthors().join(', ')}. All rights reserved."
 
                         if (JavaVersion.current().isJava8Compatible()) {
-                            task.options.addStringOption('Xdoclint:none', '-quiet')
+                            task.options.addBooleanOption('Xdoclint:none', true)
+                            task.options.quiet()
                         }
                     }
                 }


### PR DESCRIPTION
Before the fix, the following was set as Javadoc options:
```
-Xdoclint:none '-quiet'
```

After the fix, it'll be:
```
-Xdoclint:none
-quiet
```