### PR TITLE
Simplify configuration example for Kotlin DSL for release

### DIFF
--- a/subprojects/guide/src/docs/asciidoc/project-structure.adoc
+++ b/subprojects/guide/src/docs/asciidoc/project-structure.adoc
@@ -241,10 +241,9 @@ plugins {
 
 val bintrayUsername: String by project
 val bintrayApiKey: String by project
-val releaseActive: Boolean? = rootProject.findProperty("release") as Boolean?
 
 config {
-    release = if (releaseActive != null) releaseActive!! else false       //<2>
+    release = rootProject.findProperty("release").toString().toBoolean()  //<2>
 
     info {                                                                //<3>
         name        = "Sample"


### PR DESCRIPTION
This PR simplifies the evaluation of the property `release` in the Kotlin DSL example in the guide.

The simplified version relies on Kotlins `toString` method that is able to return "null" when called on objects that are null and the extension function `toBoolean` that will convert string "true" (case-insensitively) to the boolean `true` and any other string value to boolean `false`.