### PR TITLE
Improve support for integration/functional test written in kotlin

### DIFF
--- a/plugins/functionaltest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/functionaltest/FunctionalTestPlugin.groovy
+++ b/plugins/functionaltest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/functionaltest/FunctionalTestPlugin.groovy
@@ -58,6 +58,12 @@ class FunctionalTestPlugin extends AbstractKordampPlugin {
             createConfigurationsIfNeeded(project)
             createTasksIfNeeded(project)
         }
+
+        project.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+            createSourceSetsIfNeeded(project, 'kotlin')
+            createConfigurationsIfNeeded(project)
+            createTasksIfNeeded(project)
+        }
     }
 
     private void createConfigurationsIfNeeded(Project project) {

--- a/plugins/integrationtest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/integrationtest/IntegrationTestPlugin.groovy
+++ b/plugins/integrationtest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/integrationtest/IntegrationTestPlugin.groovy
@@ -58,6 +58,12 @@ class IntegrationTestPlugin extends AbstractKordampPlugin {
             createConfigurationsIfNeeded(project)
             createTasksIfNeeded(project)
         }
+
+        project.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+            createSourceSetsIfNeeded(project, 'kotlin')
+            createConfigurationsIfNeeded(project)
+            createTasksIfNeeded(project)
+        }
     }
 
     private void createConfigurationsIfNeeded(Project project) {

--- a/subprojects/guide/src/docs/asciidoc/plugins/functionaltest-gradle-plugin.adoc
+++ b/subprojects/guide/src/docs/asciidoc/plugins/functionaltest-gradle-plugin.adoc
@@ -13,8 +13,8 @@ Responsibilities:
 
  * Create two additional configurations: `functionalTestImplementation` and `functionalTestRuntimeOnly`. These configurations
    extend from `imlementation` and `runtimeOnly` respectively.
- * Create a `SourceSet` named `functionalTest` pointing to `src/main/[java|groovy]`.
- * Create a `Test` task named `functionalTest` pointing to `src/functional-test/[java|groovy]`.
+ * Create a `SourceSet` named `functionalTest` pointing to `src/main/[java|groovy|kotlin]`.
+ * Create a `Test` task named `functionalTest` pointing to `src/functional-test/[java|groovy|kotlin]`.
  * Create a `TestReport` task named `functionalTestReport`. This task is added as a dependency to `check`.
 
 NOTE: You must add testing dependencies to `functionalTestImplementation` as this configuration is independent from `testImplementation`.

--- a/subprojects/guide/src/docs/asciidoc/plugins/integrationtest-gradle-plugin.adoc
+++ b/subprojects/guide/src/docs/asciidoc/plugins/integrationtest-gradle-plugin.adoc
@@ -13,7 +13,7 @@ Responsibilities:
 
  * Create two additional configurations: `integrationTestImplementation` and `integrationTestRuntimeOnly`. These configurations
    extend from `testImplementation` and `testRuntimeOnly` respectively.
- * Create a `SourceSet` named `integrationTest` pointing to `src/main/[java|groovy]`.
- * Create a `Test` task named `integrationTest` pointing to `src/integration-test/[java|groovy]`.
+ * Create a `SourceSet` named `integrationTest` pointing to `src/main/[java|groovy|kotlin]`.
+ * Create a `Test` task named `integrationTest` pointing to `src/integration-test/[java|groovy|kotlin]`.
  * Create a `TestReport` task named `integrationTestReport`. This task is added as a dependency to `check`.
 


### PR DESCRIPTION
This PR reintroduces the option with the `IntegrationTestPlugin` and the `FunctionalTestPlugin` to run test classes within `src\integration-test\kotlin`.

Without it, integration tests written in kotlin are only executed if they reside in `src\integration-test\java` (and alike for functional tests)

Since we do not have a kotlin specific plugin within the kordamp gradle plugin suite, I based the decision of whether to apply the source set modifications on the presence of the stock kotlin gradle plugin. This may be revised when - and if - there will be a kotlin specific plugin within the kordamp suite.