### PR TITLE
Remove the IdeaPlugin based configuration for integration/functional tests to avoid an exception in IntelliJ

### DIFF
--- a/plugins/functionaltest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/functionaltest/FunctionalTestPlugin.groovy
+++ b/plugins/functionaltest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/functionaltest/FunctionalTestPlugin.groovy
@@ -78,16 +78,6 @@ class FunctionalTestPlugin extends AbstractKordampPlugin {
             functionalTestRuntimeOnly = project.configurations.create('functionalTestRuntimeOnly')
         }
         functionalTestRuntimeOnly.extendsFrom project.configurations.runtimeOnly
-
-        if (project.plugins.findPlugin('idea')) {
-            project.idea {
-                module {
-                    scopes.TEST.plus += [functionalTestImplementation]
-                    scopes.TEST.plus += [functionalTestRuntimeOnly]
-                    testSourceDirs += resolveSourceSets(project).functionalTest.allSource.srcDirs
-                }
-            }
-        }
     }
 
     private void createSourceSetsIfNeeded(Project project, String sourceSetName) {

--- a/plugins/integrationtest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/integrationtest/IntegrationTestPlugin.groovy
+++ b/plugins/integrationtest-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/integrationtest/IntegrationTestPlugin.groovy
@@ -78,16 +78,6 @@ class IntegrationTestPlugin extends AbstractKordampPlugin {
             integrationTestRuntimeOnly = project.configurations.create('integrationTestRuntimeOnly')
         }
         integrationTestRuntimeOnly.extendsFrom integrationTestImplementation, project.configurations.testRuntimeOnly
-
-        if (project.plugins.findPlugin('idea')) {
-            project.idea {
-                module {
-                    scopes.TEST.plus += [integrationTestImplementation]
-                    scopes.TEST.plus += [integrationTestRuntimeOnly]
-                    testSourceDirs += resolveSourceSets(project).integrationTest.allSource.srcDirs
-                }
-            }
-        }
     }
 
     private void createSourceSetsIfNeeded(Project project, String sourceSetName) {


### PR DESCRIPTION
Potentially resolves #189

I have the impression that the `IdeaPlugin` already correctly resolves and integrates the new source set provided by the `IntegrationTestPlugin` and the `FunctionalTestPlugin` and does not need the additional configuration.

If I'm missing something (I probably do), we should make sure not to directly access the respective plugins and hence prevent IntelliJ from throwing the following exception

```
Resolving configuration 'integrationTestImplementation' directly is not allowed.
```